### PR TITLE
Adding installation instructions for Gentoo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ You can install the flatpak package of the application from flathub using
 flatpak install flathub com.github.bilelmoussaoui.Authenticator
 ```
 
+### Gentoo
+Installing Authenticator in Gentoo Linux is as easy as follows:
+```
+emerge sys-auth/authenticator
+```
 
 ### Building from source code
 #### Dependecies


### PR DESCRIPTION
I recently introduced Authenticator into Gentoo's package manager.

As suggested in https://github.com/bilelmoussaoui/Authenticator/issues/67#issuecomment-410840291 I am filing a pull request where installation instructions for Gentoo are added into README file.