### PR TITLE
fix keyring records to have more information as to what the records represent

### DIFF
--- a/Authenticator/models/account.py
+++ b/Authenticator/models/account.py
@@ -16,11 +16,12 @@
  You should have received a copy of the GNU General Public License
  along with Authenticator. If not, see <http://www.gnu.org/licenses/>.
 """
+from hashlib import sha256
 from threading import Thread
 from time import sleep
-from hashlib import sha256
 
 from gi.repository import GObject
+
 from .clipboard import Clipboard
 from .code import Code
 from .database import Database
@@ -60,10 +61,10 @@ class Account(GObject.GObject, Thread):
     @staticmethod
     def create(name, provider, secret_id, logo):
         encrypted_secret = sha256(secret_id.encode('utf-8')).hexdigest()
-        _id = Database.get_default().insert(
-            name, provider, encrypted_secret, logo)["id"]
-        Keyring.insert(encrypted_secret, secret_id)
-        return Account(_id, name, provider, encrypted_secret, logo)
+        obj = Database.get_default().insert(name, provider, encrypted_secret, logo)
+
+        Keyring.insert(encrypted_secret, provider, name, secret_id)
+        return Account(obj['id'], name, provider, encrypted_secret, logo)
 
     @property
     def secret_code(self):

--- a/Authenticator/models/keyring.py
+++ b/Authenticator/models/keyring.py
@@ -17,6 +17,7 @@
  along with Authenticator. If not, see <http://www.gnu.org/licenses/>.
 """
 from gi import require_version
+
 require_version('Secret', '1')
 from gi.repository import Secret
 
@@ -29,7 +30,8 @@ class Keyring:
         self.schema = Secret.Schema.new(Keyring.ID,
                                         Secret.SchemaFlags.NONE,
                                         {
-                                            "id": Secret.SchemaAttributeType.STRING
+                                            "id": Secret.SchemaAttributeType.STRING,
+                                            "name": Secret.SchemaAttributeType.STRING,
                                         })
 
     @staticmethod
@@ -46,16 +48,28 @@ class Keyring:
         return password
 
     @staticmethod
-    def insert(id_, secret_code):
+    def insert(id_, provider, name, secret_code):
         """
         Insert a secret code to Keyring database
         :param id_: the encrypted id
+        :param provider: the provider's name
+        :param name: the identity/username
         :param secret_code: the secret code
         """
         schema = Keyring.get_default().schema
-        Secret.password_store_sync(schema, {
+
+        data = {
             "id": str(id_),
-        }, Secret.COLLECTION_DEFAULT, "", secret_code, None)
+            "name": str(name),
+        }
+        Secret.password_store_sync(
+            schema,
+            data,
+            Secret.COLLECTION_DEFAULT,
+            "{provider} OTP ({name})".format(provider=provider, name=name),
+            secret_code,
+            None
+        )
 
     @staticmethod
     def remove(id_):


### PR DESCRIPTION
Currently the keyring record has no text in it whatsoever. This makes the keyring record more verbose by putting the provider's name and the identity within the keyring so it's identifiable.